### PR TITLE
Make wallrun direction independent

### DIFF
--- a/scenes/WallrunPlatform.tscn
+++ b/scenes/WallrunPlatform.tscn
@@ -20,7 +20,7 @@ extents = Vector3( 0.99, 1, 1 )
 extents = Vector3( 1, 2, 1 )
 
 [node name="WallrunPlatform" type="Spatial"]
-transform = Transform( 10, 0, 0, 0, -2.18557e-08, -5, 0, 0.5, -2.18557e-07, 26, 5.75, 0 )
+transform = Transform( 10, 0, 0, 0, -2.18557e-08, -5, 0, 0.5, -2.18557e-07, 0, 0, 0 )
 
 [node name="MeshInstance" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, -4.44089e-16, 1, 0, 0, 0 )

--- a/scripts/PlayerBody.gd
+++ b/scripts/PlayerBody.gd
@@ -175,8 +175,10 @@ func _integrate_forces(state: PhysicsDirectBodyState):
 	
 	if not active:
 		return
-	
-	if Input.is_action_pressed("jump") and allow_wallrun and state.linear_velocity.z > 10:
+	# Calculates the speed in the wallrun direction, it's possible to abs()
+	# this value to allow for backwards wall running
+	var wall_run_speed = state.linear_velocity.dot(-wallrun_basis.z) if allow_wallrun else 0.0
+	if Input.is_action_pressed("jump") and allow_wallrun and wall_run_speed > 10:
 		active_wallrun = true
 		linear_velocity.y = 0.0
 	else:

--- a/scripts/WallrunTrigger.gd
+++ b/scripts/WallrunTrigger.gd
@@ -2,16 +2,40 @@ extends Area
 
 func _on_Area_body_entered(body):
 	if body.has_signal("wallrun_enter"):
+		# The direction the wall is facing (note that thi isn't actually 
+		# the opposite of the normal if the player is "behind" the wall)
+		# this doesn't really matter in this case, and the actual normal can be used
+		# without issue later on, the only important thing is that the vector
+		# points in the same direction as the normal, the actual value or orientation
+		# gets accounted for with the dot product step
+		var wall_normal : Vector3 = global_transform.basis.y
 		
-		var player_forward = body.face.global_transform.basis.z
-		var wall_x = global_transform.basis.x
-		var res = player_forward.dot(wall_x)
+		# A vector pointing to the right of the player
+		var player_right : Vector3 = body.face.global_transform.basis.x
 		
-		var s_res = sign(res) if not sign(res) == 0 else 1
-			
-		var z = wall_x * s_res
+		# A float value of 1.0 if the player right is in the same direction
+		# as the wall normal, and -1 if they are in opposite directions
+		# (or perpendicular)
+		var facing  : float = player_right.dot(wall_normal)
+		facing = 1.0 if facing > 0 else -1.0
+		
+		# Snaps the right direction of the new basis to the closest orientation
+		# of the wall normal vector(this deals with the possibility of the normal
+		# being inverted as well), projecting it on the horizontal plane
+		# in case the wall is inclined
+		var x = facing*wall_normal
+		x.y = 0.0
+		x = x.normalized()
+		# the Y of the new basis should always point UP, the basis simply
+		# rotates around the Y axis
 		var y = Vector3.UP
-		var x = y.cross(z)
+		# Godot uses right handed coordinates. So, to get an orthonormal basis,
+		# x.cross(y) == z, y.cross(z) == x, z.cross(x) == y
+		# this way, if you have any 2 vectors of an orthonormal basis, you can
+		# get the third.
+		# orthonormal means that all the vectors are perpendicular to each
+		# other (ortho), and that they all have length 1.0 (normal)
+		var z = x.cross(y)
 		
 		body.emit_signal("wallrun_enter", Basis(x, y, z))
 


### PR DESCRIPTION
Wall run should work with the wall in almost orientation, failing only if the wall normal is completely vertical, but then it's just running, also fixes the speed test only checking the global Z direction